### PR TITLE
Added selectAll checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,12 +84,8 @@
 				var jqInsertElement = $('#sidebar > ul');
 				for (var i=0; i<internal_names.length; i++) {
 					var internal_name = internal_names[i];
-					var display_name = locations[internal_name].display_name;
-					if (internal_name == display_name) {
-						jqInsertElement.append('<li><label><input type="checkbox" name="'+internal_name+'"/><span class="itemName">'+internal_name+'</span></label></li>');
-					} else {
-						jqInsertElement.append('<li><label><input type="checkbox" name="'+internal_name+'"/><span class="itemName">'+display_name+' -- '+internal_name+'</span></label></li>');
-					}
+					var display_name = getDisplayName(internal_name);
+					jqInsertElement.append('<li><label><input type="checkbox" name="'+internal_name+'"/><span class="itemName">'+display_name+'</span></label></li>');
 				}
 
 				var icons = [L.divIcon({className: 'div-icon0'}),
@@ -116,12 +112,7 @@
 						if (names.indexOf(this.name) < 0) {
 							names.push(this.name);
 						}
-						var name_str;
-						if (this.name == locations[this.name].display_name) {
-							name_str = this.name;
-						} else {
-							name_str = locations[this.name].display_name + ' -- ' + this.name;
-						}
+						var name_str = getDisplayName(this.name);
 						for (var i=0; i<locations[this.name].locations.length; i++) {
 							var coords = map.unproject([8*3000+4*locations[this.name].locations[i][0], 8*2500+4*locations[this.name].locations[i][1]], map.getMaxZoom()-1);
 							markers[this.name].push(L.marker(coords, {icon: icons[names.indexOf(this.name) % 12], title:name_str}).addTo(map));
@@ -145,12 +136,20 @@
 			
 			});
 				
-				function showPreset(name) {
-					$('input:checked').prop('checked', false).trigger("change");
-					for (var i=0; i<presets[name].length; i++) {
-						$('input[name="'+presets[name][i]+'"]').prop('checked', true).trigger("change");
-					}
-				};
+			function showPreset(name) {
+				$('input:checked').prop('checked', false).trigger("change");
+				for (var i=0; i<presets[name].length; i++) {
+					$('input[name="'+presets[name][i]+'"]').prop('checked', true).trigger("change");
+				}
+			};
+
+			function getDisplayName(internalName) {
+				if (internalName == locations[internalName].display_name) {
+					return internalName;
+				} else {
+					return locations[internalName].display_name + ' -- ' + internalName;
+				}
+			};
 		</script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,10 @@
 	<body>
 		<div id="botw_map"></div>
 		<div id="sidebar">
-			<input type="text" class="search" />
+			<div>
+				<input type="checkbox" id="selectAll" disabled />
+				<input type="text" class="search" />
+			</div>
 			<ul class="list"></ul>
 		</div>
 		<div>Note that many objects are dynamically generated and are not included in this data.</div>
@@ -104,7 +107,7 @@
 				var markers = {};
 				var names = [];
 				
-				$('input').change(function () {
+				$('.list input').change(function () {
 				
 					if ($(this).is(':checked')) {
 						
@@ -133,9 +136,21 @@
 				for (var i=0; i<preset_names.length; i++) {
 					$('body').append('<div><a href="javascript:showPreset(\''+preset_names[i]+'\')">Preset: '+preset_names[i]+'</div>');
 				}
-			
+
+				$('#selectAll').change(function() {
+					if ($(this).is(':checked')) {
+						$('.list input:checkbox:not(:checked)').prop('checked', true).trigger('change');
+					} else {
+						$('.list input:checkbox:checked').prop('checked', false).trigger('change');
+					}
+				});
+
+				sidebarList.on('searchComplete', function() {
+					$('#selectAll').prop('disabled', sidebarList.matchingItems.length > 1000);
+				});
+
 			});
-				
+
 			function showPreset(name) {
 				$('input:checked').prop('checked', false).trigger("change");
 				for (var i=0; i<presets[name].length; i++) {


### PR DESCRIPTION
- The "Select All" checkbox will _only_ select/deselect the currently filtered list of items.
- Safety added to prevent checking it when many (currently >1000) items are listed.

Note: Its checked state does not change even if you change the search text. You can just work around it by toggling it twice.
